### PR TITLE
Compile on !OpenBSD, but throw runtime errors when not supported

### DIFF
--- a/ext/pledge/extconf.rb
+++ b/ext/pledge/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 have_header 'unistd.h'
-have_func('pledge') || raise("pledge(2) not present, cannot built extension")
+have_func('pledge')
 have_func('unveil')
 $CFLAGS << " -O0 -g -ggdb" if ENV['DEBUG']
 $CFLAGS << " -Wall"

--- a/ext/pledge/pledge.c
+++ b/ext/pledge/pledge.c
@@ -13,6 +13,7 @@ static VALUE rb_pledge(int argc, VALUE* argv, VALUE pledge_class) {
   const char * prom = NULL;
   const char * execprom = NULL;
 
+#ifdef HAVE_PLEDGE
   rb_scan_args(argc, argv, "11", &promises, &execpromises);
 
   if (!NIL_P(promises)) {
@@ -41,6 +42,9 @@ static VALUE rb_pledge(int argc, VALUE* argv, VALUE pledge_class) {
         rb_raise(ePledgeError, "pledge error");
     }
   }
+#else
+  rb_raise(rb_eLoadError, "pledge not supported");
+#endif
 
   return Qnil;
 }

--- a/lib/unveil.rb
+++ b/lib/unveil.rb
@@ -1,9 +1,6 @@
 # frozen-string-literal: true
 
 require_relative 'pledge'
-# :nocov:
-raise LoadError, "unveil not supported" unless Pledge.respond_to?(:_unveil, true)
-# :nocov:
 
 module Pledge
   # Limit access to the file system using unveil(2).  +paths+ should be a hash
@@ -25,6 +22,8 @@ module Pledge
   # which denies all access to the file system if +unveil_without_lock+
   # was not called previously.
   def unveil(paths)
+    raise LoadError, "unveil not supported" unless Pledge.respond_to?(:_unveil, true)
+
     if paths.empty?
       paths = {'/'=>''}
     end
@@ -35,6 +34,8 @@ module Pledge
 
   # Same as unveil, but allows for future calls to unveil or unveil_without_lock.
   def unveil_without_lock(paths)
+    raise LoadError, "unveil not supported" unless Pledge.respond_to?(:_unveil, true)
+
     paths = Hash[paths]
 
     paths.to_a.each do |path, perm|


### PR DESCRIPTION
I use this on my servers that run OpenBSD, but in other development environments like macOS, it would be helpful to at least be able to compile this module when included in a Gemfile so that Gemfile.lock remains the same.

Of course, at runtime the pledge/unveil calls fail, but this is skipped in the development environment by checking the OS.